### PR TITLE
Fix 'AutoscalingRoleArn' typo

### DIFF
--- a/modules/auto-scalers.yaml
+++ b/modules/auto-scalers.yaml
@@ -54,7 +54,7 @@ Resources:
     Type: "AWS::ApplicationAutoScaling::ScalableTarget"
     Properties:
       ResourceId: service/Grid/NodeChrome
-      RoleARN: !ImportValue AutoscalingRoleArn
+      RoleARN: !ImportValue AutoScalingRoleArn
       ScalableDimension: "ecs:service:DesiredCount"
       ServiceNamespace: "ecs"
       MinCapacity: 1


### PR DESCRIPTION
Following the README, this particular stack failed to deploy seemingly just because of this typo. This fix allows it to deploy successfully.