### PR TITLE
Output GridLoadBalancer DNS name

### DIFF
--- a/modules/network.yaml
+++ b/modules/network.yaml
@@ -207,3 +207,8 @@ Outputs:
     Value: !Ref GridHubGroup
     Export:
       Name: GridHubGroupArn
+  GridLoadBalancerDNSName:
+    Description: "Grid load balancer DNS name"
+    Value: !GetAtt GridLoadBalancer.DNSName
+    Export:
+      Name: GridLoadBalancerDNSName


### PR DESCRIPTION
Exporting the DNS name of the load balancer allows other resources in other stacks, e.g. Lambda functions hosting the example code in this repository that want to use the Hub, to specify the correct DNS name automatically configured for the load balancer without someone having to manually define it.